### PR TITLE
Fix error on Vercel deployment by adding json-schema dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "eventsource": "^3.0.2",
     "express": "^4.21.2",
     "framer-motion": "^11.15.0",
+    "json-schema": "^0.4.0",
     "lodash": "^4.17.21",
     "lucide-react": "^0.469.0",
     "next": "^15.1.3",


### PR DESCRIPTION
Add `json-schema` package to `dependencies` in `package.json`.

* Add `"json-schema": "^0.4.0"` to the dependencies section in `package.json`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Rhysmalcolm13/multimodal-mcp-client/pull/2?shareId=49f9e0b0-ccc6-444e-9fe8-f6454241e7ff).